### PR TITLE
Fixed typo in send-keys

### DIFF
--- a/src/nodes/send-keys.html
+++ b/src/nodes/send-keys.html
@@ -139,7 +139,7 @@
 				value : 500,
 				validate : RED.validators.number()
 			},
-			clearval : {
+			clearVal : {
 				value : false
 			}
 		},


### PR DESCRIPTION
You couldn't tick the "Clear" checkbox because the value was named `clearval` instead of `clearVal` as expected by the `<label for="node-input-clearVal">`